### PR TITLE
Fix recipe to work with latest rattler-build release

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -21,7 +21,7 @@ build:
   python:
     entry_points:
       - calcam = calcam:start_gui
-  number: 3
+  number: 4
 
 requirements:
   host:
@@ -50,7 +50,7 @@ tests:
         # https://github.com/conda-forge/opencv-feedstock/issues/401
         - if: linux
           then:
-            - libopencv *=headless*
+            - libopencv *headless*
 
 about:
   homepage: http://euratom-software.github.io/calcam/html/index.html


### PR DESCRIPTION
Fix invalid build string glob `*=headless*` to `*headless*`. The `=` character is not allowed in build string patterns.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
